### PR TITLE
Removed `--dev` from composer require command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Helper Class Generator to manage your forms and table inside your filament app
 ## Installation
 
 ```bash
-composer require tomatophp/filament-helpers --dev
+composer require tomatophp/filament-helpers
 ```
 
 ## Using


### PR DESCRIPTION
As the title says, the require shouldn't have `--dev` as far as I can tell. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation command for the `tomatophp/filament-helpers` package by removing the `--dev` flag, indicating a change in its dependency classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->